### PR TITLE
[resource] google_gke: add port_override option

### DIFF
--- a/sdm/internal/sdk/models.go
+++ b/sdm/internal/sdk/models.go
@@ -1749,6 +1749,8 @@ type GoogleGKE struct {
 	ID string `json:"id"`
 	// Unique human-readable name of the Resource.
 	Name string `json:"name"`
+	// The local port used by clients to connect to this resource.
+	PortOverride int32 `json:"portOverride"`
 	// The ID of the remote identity group to use for remote identity connections.
 	RemoteIdentityGroupID string `json:"remoteIdentityGroupId"`
 	// The username to use for healthchecks, when clients otherwise connect with their own remote identity username.

--- a/sdm/resource_resource.go
+++ b/sdm/resource_resource.go
@@ -2972,6 +2972,12 @@ func resourceResource() *schema.Resource {
 							Required:    true,
 							Description: "Unique human-readable name of the Resource.",
 						},
+						"port_override": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "The local port used by clients to connect to this resource.",
+						},
 						"remote_identity_group_id": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -9792,6 +9798,11 @@ func convertResourceToPlumbing(d *schema.ResourceData) sdm.Resource {
 			Subdomain:                         convertStringToPlumbing(raw["subdomain"]),
 			Tags:                              convertTagsToPlumbing(raw["tags"]),
 		}
+		override, ok := raw["port_override"].(int)
+		if !ok || override == 0 {
+			override = -1
+		}
+		out.PortOverride = int32(override)
 		return out
 	}
 	if list := d.Get("google_gke_user_impersonation").([]interface{}); len(list) > 0 {
@@ -11743,6 +11754,7 @@ func resourceResourceCreate(ctx context.Context, d *schema.ResourceData, cc *sdm
 				"endpoint":                             (v.Endpoint),
 				"healthcheck_namespace":                (v.HealthcheckNamespace),
 				"name":                                 (v.Name),
+				"port_override":                        (v.PortOverride),
 				"remote_identity_group_id":             (v.RemoteIdentityGroupID),
 				"remote_identity_healthcheck_username": (v.RemoteIdentityHealthcheckUsername),
 				"secret_store_id":                      (v.SecretStoreID),
@@ -13761,6 +13773,7 @@ func resourceResourceRead(ctx context.Context, d *schema.ResourceData, cc *sdm.C
 				"endpoint":                             (v.Endpoint),
 				"healthcheck_namespace":                (v.HealthcheckNamespace),
 				"name":                                 (v.Name),
+				"port_override":                        (v.PortOverride),
 				"remote_identity_group_id":             (v.RemoteIdentityGroupID),
 				"remote_identity_healthcheck_username": (v.RemoteIdentityHealthcheckUsername),
 				"secret_store_id":                      (v.SecretStoreID),


### PR DESCRIPTION
Partially resolves https://github.com/strongdm/terraform-provider-sdm/issues/46

This adds a port_override option to the google_gke resource.